### PR TITLE
Fix blog route warnings and author assets

### DIFF
--- a/blog/2019-05-28-first-blog-post.md
+++ b/blog/2019-05-28-first-blog-post.md
@@ -1,5 +1,6 @@
 ---
 title: Removed example post
+slug: first-blog-post-legacy
 authors: [slorber]
 tags: [archived]
 draft: true

--- a/blog/2019-05-28-first-blog-post.mdx
+++ b/blog/2019-05-28-first-blog-post.mdx
@@ -1,6 +1,3 @@
-import AuthorCard from '@site/src/components/AuthorCard';
-
----
 ---
 slug: first-blog-post
 title: First Blog Post
@@ -8,6 +5,8 @@ authors: [slorber]
 tags: [archived]
 draft: true
 ---
+
+import AuthorCard from '@site/src/components/AuthorCard';
 
 <AuthorCard name="Sébastien Lorber" title="Docusaurus maintainer" image="/img/yangshun.png" linkedin="https://sebastienlorber.com" github="slorber" />
 

--- a/blog/2019-05-29-long-blog-post.md
+++ b/blog/2019-05-29-long-blog-post.md
@@ -1,5 +1,6 @@
 ---
 title: Removed example post
+slug: long-blog-post-legacy
 authors: [slorber]
 tags: [archived]
 draft: true

--- a/blog/2019-05-29-long-blog-post.mdx
+++ b/blog/2019-05-29-long-blog-post.mdx
@@ -1,12 +1,11 @@
-import AuthorCard from '@site/src/components/AuthorCard';
-
----
 ---
 title: Removed example post
 authors: [slorber]
 tags: [archived]
 draft: true
 ---
+
+import AuthorCard from '@site/src/components/AuthorCard';
 
 <AuthorCard name="Sébastien Lorber" title="Docusaurus maintainer" image="/img/yangshun.png" linkedin="https://sebastienlorber.com" github="slorber" />
 

--- a/blog/2021-08-01-mdx-blog-post.mdx
+++ b/blog/2021-08-01-mdx-blog-post.mdx
@@ -1,5 +1,4 @@
 ---
----
 title: Removed example post (MDX)
 authors: [slorber]
 tags: [archived]

--- a/blog/2025-11-08-twelve-factor-app-methodology.md
+++ b/blog/2025-11-08-twelve-factor-app-methodology.md
@@ -1,5 +1,6 @@
 ---
 title: "Twelve-Factor App methodology — twelve quick rules for modern apps"
+slug: twelve-factor-app-methodology-legacy
 authors: [marcelo-m7]
 tags: [architecture, twelve-factor, best-practices]
 draft: true

--- a/blog/2025-11-08-twelve-factor-app-methodology.mdx
+++ b/blog/2025-11-08-twelve-factor-app-methodology.mdx
@@ -1,10 +1,10 @@
-import AuthorCard from '@site/src/components/AuthorCard';
-
 ---
 title: "Twelve-Factor App methodology — twelve quick rules for modern apps"
 authors: [marcelo-m7]
 tags: [architecture, twelve-factor, best-practices]
 ---
+
+import AuthorCard from '@site/src/components/AuthorCard';
 
 <AuthorCard name="Marcelo Santos" title="Founder & Maintainer" image="/img/marcelo-m7-avatar.svg" linkedin="https://www.linkedin.com/in/marcelo-m7/" github="https://github.com/marcelo-m7" />
 

--- a/blog/authors/marcelo-m7/index.md
+++ b/blog/authors/marcelo-m7/index.md
@@ -8,6 +8,8 @@ draft: true
 
 Marcelo (GitHub: `marcelo-m7`) is the founder and maintainer of MonaDocs. He focuses on developer experience, documentation tooling, and building internal tools that make publishing and maintaining docs easier.
 
+<!-- truncate -->
+
 Contact & links
 
 - LinkedIn: https://www.linkedin.com/in/marcelo-m7/

--- a/src/components/AuthorCard/index.js
+++ b/src/components/AuthorCard/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './styles.module.css';
 
-export default function AuthorCard({ name, title, image = '/img/marcelo-m7-avatar.png', linkedin, github, children }) {
+export default function AuthorCard({ name, title, image = '/img/marcelo-m7-avatar.svg', linkedin, github, children }) {
   return (
     <div className={styles.card}>
       <img className={styles.avatar} src={image} alt={name} onError={(e) => { e.currentTarget.onerror = null; e.currentTarget.src = '/img/marcelo-m7-avatar.svg'; }} />


### PR DESCRIPTION
## Summary
- normalize blog MDX front matter and assign legacy slugs to eliminate duplicate route warnings
- add truncation marker to the Marcelo author page and update the shared author card to use an existing avatar asset
- capture refreshed screenshots for dev and production builds to document the visual audit

## Testing
- npm test
- npm run build

- [x] Scope reviewed
- [x] Tests executed locally
- [x] No breaking changes introduced

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fd06189e08331a535bde12863cb44)